### PR TITLE
fix bug in xmatch where one check function did not return value

### DIFF
--- a/formulas/functions/look.py
+++ b/formulas/functions/look.py
@@ -158,6 +158,7 @@ def xmatch(lookup_value, lookup_array, match_type=1):
         def check(j, x, val, r):
             if match(x):
                 r[0] = j
+                return True
 
     convert = lambda x: x
     if t_id == 1:


### PR DESCRIPTION
in one branch in xmatch, the `check` function never returns a value, so the following `break` statement will never trigger. This means if there is more than one match in the range, the final result will be the last match, instead of the first.