### PR TITLE
refresh environment binder for 2021

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,18 +1,20 @@
 name: formulas
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
-  - docutils
-  - flask
-  - jupyterlab >=0.35.5,<0.36
+  # pull in all non-dev `extra` dependencies as of last release
+  - formulas-all
+  # a useful extra from schedula
   - multiprocess
-  - numpy >=1.15
-  - openpyxl
+  # baseline interactive environment
+  - jupyterlab >=3,<4
+  - ipython >=7.20,<8
+  # runtime
+  - python >=3.9,<3.10
   - pip
-  - python >=3.7,<3.8.0a0
-  - python-graphviz
-  - regex
-  - tornado<6
+  # icky pins
+  - parso ==0.8.*
   - pip:
-    - schedula >=1.1.1
+    # gah, don't even want, but `pip check` complains otherwise :(
+    - jupyter-telemetry >=0.1.0

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,2 +1,14 @@
 #!/usr/bin/env bash
-python -m pip install -e . --ignore-installed --no-dependencies
+set -eux
+
+# force installing over the conda version
+python -m pip install -e . --ignore-installed --no-deps
+
+# install the rest of the stuff: don't reinstall if versions are ok
+python -m pip install -e .[all,dev]
+
+# not compatible with lab 3
+jupyter labextension uninstall --no-build jupyter-offlinenotebook || echo "ok"
+
+# this is optional, everything will _probably_ work, even if pip does bad things
+python -m pip check


### PR DESCRIPTION
## Status
**READY**

## Description

Congratulations on the 1.1.0 release, and as always, thanks for this software! Over on conda-forge, i just pushed out the build of the latest stuff, and added some child packages for `-plot`, `-excel`, and `-all`. As I was looking over the code, I noticed the binder we put together on #31 was starting to show it's age.

This updates the binder demo for 2021, still pulling in the bulk of the dependencies with `conda` (by way of the shiny `formulas-all`), then updating with whatever's clever with `pip` from `[dev,all]`. The big delta is JupyterLab 3, which:
- adds machinery, and starts the process, of internationalizing the UI
- adds a breakpoint debugger (not supported by all kernels... yet)
- makes adding new extensions a lot easier (e.g. no nodejs)

## Related Issues

List related Issues against other branches:

n/a

## Todos

n/a

## Steps to Test or Reproduce

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bollwyvl/formulas/refresh-binder?urlpath=lab%2Ftree%2Fbinder%2Findex.ipynb)

## Possible Future Work

On this PR, or perhaps on subsequent ones, some cool additions might be:
- the [xeus python kernel](https://github.com/jupyter-xeus/xeus-python), which supports the JupyterLab 3 breakpoint debugger
  - might be neat to show intermediate function inputs without print statements 
  - support may well land in `ipykernel` natively
- some more top-shelf Jupyter Widgets that would complement interactive visualization of `formulas`
  - [ipywidgets](https://github.com/jupyter-widgets/ipywidgets), [bqplot](https://github.com/bqplot/bqplot), [ipyleaflet](https://github.com/jupyter-widgets/ipyleaflet), [ipympl](https://github.com/matplotlib/ipympl)
- some less-top-shelf, experimental Widgets (maintained by your humble PR requester)
  - [ipyelk](https://github.com/jupyrdf/ipyelk), which wraps [ELK](https://github.com/kieler/elkjs)
    -  might become an interesting companion for graphviz-based visualization
  - [wxyz](https://github.com/deathbeds/wxyz), which wraps the lumino datagrid, JupyterLab internals
    - might be interesting for building full apps powered by formulas
- [voila](https://github.com/voila-dashboards/voila)
  - might be interesting for demonstrating full dashboard applications
- [jupyterlab-classic](https://github.com/jtpio/jupyterlab-classic)
  - for that old-school charm
- [jupyterlab-lsp](https://github.com/krassowski/jupyterlab-lsp), which wraps the [Language Server Protocol](https://langserver.org/)
  - augments existing Jupyter features like completion
  - adds new interactive features like go-to-reference and renaming