### PR TITLE
fix import collections.abc deprection

### DIFF
--- a/formulas/functions/__init__.py
+++ b/formulas/functions/__init__.py
@@ -291,7 +291,7 @@ def flatten(v, check=is_number):
             yield from v.ravel()
         else:
             yield from filter(check, v.ravel())
-    elif not isinstance(v, str) and isinstance(v, collections.Iterable):
+    elif not isinstance(v, str) and isinstance(v, collections.abc.Iterable):
         for el in v:
             yield from flatten(el, check)
     elif not check or check(v):


### PR DESCRIPTION
formulas/functions/__init__.py:294: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    elif not isinstance(v, str) and isinstance(v, collections.Iterable):