### PR TITLE
Allow the first parameter to be empty in a function call.

### DIFF
--- a/formulas/tokens/operator.py
+++ b/formulas/tokens/operator.py
@@ -109,7 +109,7 @@ class Separator(Operator):
     _re_process = regex.compile(r'^\s*(?P<name>,)$')
 
     def ast(self, tokens, stack, builder):
-        if tokens and isinstance(tokens[-1], Separator):
+        if tokens and (isinstance(tokens[-1], Separator) or isinstance(tokens[-1], Parenthesis)):
             from .operand import Empty
             Empty().ast(tokens, stack, builder)
         super(Operator, self).ast(tokens, stack, builder)

--- a/formulas/tokens/operator.py
+++ b/formulas/tokens/operator.py
@@ -109,7 +109,7 @@ class Separator(Operator):
     _re_process = regex.compile(r'^\s*(?P<name>,)$')
 
     def ast(self, tokens, stack, builder):
-        if tokens and (isinstance(tokens[-1], Separator) or isinstance(tokens[-1], Parenthesis)):
+        if tokens and (isinstance(tokens[-1], Separator) or tokens[-1].get_name == '('):
             from .operand import Empty
             Empty().ast(tokens, stack, builder)
         super(Operator, self).ast(tokens, stack, builder)

--- a/test/test_cell.py
+++ b/test/test_cell.py
@@ -523,6 +523,7 @@ class TestCell(unittest.TestCase):
          '<Ranges>(A1)=[[0]]'),
         ('A1', '=IFS(FALSE, "FIRST", FALSE, "SECOND")', {},
          '<Ranges>(A1)=[[#N/A]]'),
+        ('A1', '=IF(,FALSE,"PASS")', {}, '<Ranges>(A1)=[[\'PASS\']]'),
         ('A1', '=ROW(4:7)', inp_ranges('4:7'), '<Ranges>(A1)=[[4]]'),
         ('A1', '=ROW(B8:D8:F7:H8 D7:E8)',
          inp_ranges('B8:D8', 'F7:H8', 'D7:E8'), '<Ranges>(A1)=[[7]]'),

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -63,7 +63,8 @@ class TestParser(unittest.TestCase):
         ('=10  ^  -  2', '10^u-2'),
         ('=10^- + -  + + +2', '10^u+2'),
         ('=ATAN2( 10 , 2)', 'ATAN2(10,2)'),
-        ('=DAYS360( 10 , 2)', 'DAYS360(10,2)')
+        ('=DAYS360( 10 , 2)', 'DAYS360(10,2)'),
+        ('=FIRSTPARAMEMPTY(,,1)', 'FIRSTPARAMEMPTY(,,1)'),
     )
     def test_valid_formula(self, case):
         inputs, result = case


### PR DESCRIPTION
## Status
**READY**

## Description
Emit a separator token if the previous token is a separator, (i.e., we are making an empty statement) or if the previous token was the start of a parenthetical group (i.e., the first parameter is empty).

The use case here is primarily to support third party APIs with optional first parameters. For instance, a `=GETDATA(<ids>, <filter>)` API could allow a user to leave out the <ids> parameter and just apply a filter to the entire dataset. This may look like `=GETDATA(,"Country = 'US'")`

## Steps to Test or Reproduce
Added two new test cases
```('=FIRSTPARAMEMPTY(,,1)', 'FIRSTPARAMEMPTY(,,1)'),```

As in Excel, we'll treat the first empty param as Falsy.
```        ('A1', '=IF(,FALSE,"PASS")', {}, '<Ranges>(A1)=[[\'PASS\']]'),```
